### PR TITLE
New branch 'pristines-on-demand-on-issue4892': update fetches minimal…

### DIFF
--- a/subversion/include/private/svn_wc_private.h
+++ b/subversion/include/private/svn_wc_private.h
@@ -47,6 +47,18 @@ extern "C" {
 #endif /* __cplusplus */
 
 
+/* The callback invoked by svn_wc__textbase_sync() to fetch the text-base
+   contents identified by REPOS_ROOT_URL, REPOS_RELPATH and REVISION. */
+typedef svn_error_t *(*svn_wc__textbase_hydrate_cb_t)(
+  void *baton,
+  const char *repos_root_url,
+  const char *repos_relpath,
+  svn_revnum_t revision,
+  svn_stream_t *contents,
+  svn_cancel_func_t cancel_func,
+  void *cancel_baton,
+  apr_pool_t *scratch_pool);
+
 /* Return TRUE iff CLHASH (a hash whose keys are const char *
    changelist names) is NULL or if LOCAL_ABSPATH is part of a changelist in
    CLHASH. */
@@ -1523,6 +1535,8 @@ svn_wc__get_update_editor(const svn_delta_editor_t **editor,
                           svn_boolean_t clean_checkout,
                           const char *diff3_cmd,
                           const apr_array_header_t *preserved_exts,
+                          svn_wc__textbase_hydrate_cb_t hydrate_func,
+                          void *hydrate_baton,
                           svn_wc_dirents_func_t fetch_dirents_func,
                           void *fetch_dirents_baton,
                           svn_wc_conflict_resolver_func2_t conflict_func,
@@ -2314,18 +2328,6 @@ svn_wc__upgrade(svn_wc_context_t *wc_ctx,
                 void *notify_baton,
                 apr_pool_t *scratch_pool);
 
-/* The callback invoked by svn_wc__textbase_sync() to fetch the text-base
-   contents identified by REPOS_ROOT_URL, REPOS_RELPATH and REVISION. */
-typedef svn_error_t *(*svn_wc__textbase_hydrate_cb_t)(
-  void *baton,
-  const char *repos_root_url,
-  const char *repos_relpath,
-  svn_revnum_t revision,
-  svn_stream_t *contents,
-  svn_cancel_func_t cancel_func,
-  void *cancel_baton,
-  apr_pool_t *scratch_pool);
-
 /* Synchronize the state of the text-base contents for the LOCAL_ABSPATH tree.
    If ALLOW_HYDRATE is true, fetch the required but missing text-base contents
    using the provided HYDRATE_CALLBACK and HYDRATE_BATON.  If ALLOW_DEHYDRATE
@@ -2340,6 +2342,27 @@ svn_wc__textbase_sync(svn_wc_context_t *wc_ctx,
                       svn_cancel_func_t cancel_func,
                       void *cancel_baton,
                       apr_pool_t *scratch_pool);
+
+/**
+ * @since New in 1.15.
+ */
+svn_error_t *
+svn_wc__crawl_revisions6(svn_wc_context_t *wc_ctx,
+                         const char *local_abspath,
+                         const svn_ra_reporter3_t *reporter,
+                         void *report_baton,
+                         svn_boolean_t restore_files,
+                         svn_depth_t depth,
+                         svn_boolean_t honor_depth_exclude,
+                         svn_boolean_t depth_compatibility_trick,
+                         svn_boolean_t use_commit_times,
+                         svn_wc__textbase_hydrate_cb_t hydrate_func,
+                         void *hydrate_baton,
+                         svn_cancel_func_t cancel_func,
+                         void *cancel_baton,
+                         svn_wc_notify_func2_t notify_func,
+                         void *notify_baton,
+                         apr_pool_t *scratch_pool);
 
 #ifdef __cplusplus
 }

--- a/subversion/libsvn_client/client.h
+++ b/subversion/libsvn_client/client.h
@@ -40,6 +40,7 @@
 #include "private/svn_client_private.h"
 #include "private/svn_diff_tree.h"
 #include "private/svn_editor.h"
+#include "private/svn_wc_private.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -1250,6 +1251,17 @@ svn_client__textbase_sync(const char *local_abspath,
                           svn_boolean_t allow_dehydrate,
                           svn_client_ctx_t *ctx,
                           apr_pool_t *scratch_pool);
+
+/* ...
+ *
+ * RA_SESSION may be null; in that case, it will open a new session upon
+ * first use. */
+svn_error_t *
+svn_client__textbase_get_hydrator(svn_wc__textbase_hydrate_cb_t *hydrate_func,
+                                  void **hydrate_baton,
+                                  svn_ra_session_t *ra_session,
+                                  svn_client_ctx_t *ctx,
+                                  apr_pool_t *result_pool);
 
 #ifdef __cplusplus
 }

--- a/subversion/libsvn_client/switch.c
+++ b/subversion/libsvn_client/switch.c
@@ -442,6 +442,9 @@ svn_client__switch_internal(svn_revnum_t *result_rev,
    * resolve any conflicts that were raised. */
   if (! err1 && ctx->conflict_func2)
     {
+      SVN_ERR(svn_client__textbase_sync(local_abspath, TRUE, TRUE,
+                                        ctx, pool));
+
       err1 = svn_client__resolve_conflicts(NULL, conflicted_paths, ctx, pool);
     }
 

--- a/subversion/libsvn_client/textbase.c
+++ b/subversion/libsvn_client/textbase.c
@@ -85,6 +85,24 @@ textbase_hydrate_cb(void *baton,
 }
 
 svn_error_t *
+svn_client__textbase_get_hydrator(svn_wc__textbase_hydrate_cb_t *hydrate_func,
+                                  void **hydrate_baton,
+                                  svn_ra_session_t *ra_session,
+                                  svn_client_ctx_t *ctx,
+                                  apr_pool_t *result_pool)
+{
+  textbase_hydrate_baton_t *baton = apr_pcalloc(result_pool, sizeof(*baton));
+
+  baton->pool = result_pool;
+  baton->ctx = ctx;
+  baton->ra_session = ra_session;
+
+  *hydrate_func = textbase_hydrate_cb;
+  *hydrate_baton = baton;
+  return SVN_NO_ERROR;
+}
+
+svn_error_t *
 svn_client__textbase_sync(const char *local_abspath,
                           svn_boolean_t allow_hydrate,
                           svn_boolean_t allow_dehydrate,
@@ -99,6 +117,7 @@ svn_client__textbase_sync(const char *local_abspath,
   baton.ctx = ctx;
   baton.ra_session = NULL;
 
+  SVN_DBG(("svn_client__textbase_sync(%d,%d)", allow_hydrate, allow_dehydrate));
   SVN_ERR(svn_wc__textbase_sync(ctx->wc_ctx, local_abspath,
                                 allow_hydrate, allow_dehydrate,
                                 textbase_hydrate_cb, &baton,

--- a/subversion/libsvn_wc/adm_crawler.c
+++ b/subversion/libsvn_wc/adm_crawler.c
@@ -209,11 +209,17 @@ maybe_restore_node(svn_wc__db_t *db,
 
       if (dirent_kind == svn_node_none)
         {
-          SVN_ERR(restore_node(db, local_abspath,
+  return SVN_NO_ERROR;
+          err = (restore_node(db, local_abspath,
                                wrk_kind, conflicted, use_commit_times,
                                cancel_func, cancel_baton,
                                notify_func, notify_baton,
                                scratch_pool));
+          if (err)
+            {
+              svn_handle_warning2(stdout, err, "DBG: ");
+              svn_error_clear(err);
+            }
         }
     }
 
@@ -675,20 +681,22 @@ report_revisions_and_depths(svn_wc__db_t *db,
 
 
 svn_error_t *
-svn_wc_crawl_revisions5(svn_wc_context_t *wc_ctx,
-                        const char *local_abspath,
-                        const svn_ra_reporter3_t *reporter,
-                        void *report_baton,
-                        svn_boolean_t restore_files,
-                        svn_depth_t depth,
-                        svn_boolean_t honor_depth_exclude,
-                        svn_boolean_t depth_compatibility_trick,
-                        svn_boolean_t use_commit_times,
-                        svn_cancel_func_t cancel_func,
-                        void *cancel_baton,
-                        svn_wc_notify_func2_t notify_func,
-                        void *notify_baton,
-                        apr_pool_t *scratch_pool)
+svn_wc__crawl_revisions6(svn_wc_context_t *wc_ctx,
+                         const char *local_abspath,
+                         const svn_ra_reporter3_t *reporter,
+                         void *report_baton,
+                         svn_boolean_t restore_files,
+                         svn_depth_t depth,
+                         svn_boolean_t honor_depth_exclude,
+                         svn_boolean_t depth_compatibility_trick,
+                         svn_boolean_t use_commit_times,
+                         svn_wc__textbase_hydrate_cb_t hydrate_func,
+                         void *hydrate_baton,
+                         svn_cancel_func_t cancel_func,
+                         void *cancel_baton,
+                         svn_wc_notify_func2_t notify_func,
+                         void *notify_baton,
+                         apr_pool_t *scratch_pool)
 {
   svn_wc__db_t *db = wc_ctx->db;
   svn_error_t *fserr, *err;
@@ -875,6 +883,36 @@ svn_wc_crawl_revisions5(svn_wc_context_t *wc_ctx,
       svn_error_compose(err, fserr);
     }
   return svn_error_trace(err);
+}
+
+svn_error_t *
+svn_wc_crawl_revisions5(svn_wc_context_t *wc_ctx,
+                        const char *local_abspath,
+                        const svn_ra_reporter3_t *reporter,
+                        void *report_baton,
+                        svn_boolean_t restore_files,
+                        svn_depth_t depth,
+                        svn_boolean_t honor_depth_exclude,
+                        svn_boolean_t depth_compatibility_trick,
+                        svn_boolean_t use_commit_times,
+                        svn_cancel_func_t cancel_func,
+                        void *cancel_baton,
+                        svn_wc_notify_func2_t notify_func,
+                        void *notify_baton,
+                        apr_pool_t *scratch_pool)
+{
+  SVN_ERR(svn_wc__crawl_revisions6(wc_ctx, local_abspath,
+                                   reporter, report_baton,
+                                   restore_files,
+                                   depth,
+                                   honor_depth_exclude,
+                                   depth_compatibility_trick,
+                                   use_commit_times,
+                                   NULL, NULL,
+                                   cancel_func, cancel_baton,
+                                   notify_func, notify_baton,
+                                   scratch_pool));
+  return SVN_NO_ERROR;
 }
 
 /*** Copying stream ***/

--- a/subversion/libsvn_wc/deprecated.c
+++ b/subversion/libsvn_wc/deprecated.c
@@ -3643,6 +3643,7 @@ svn_wc_get_update_editor4(const svn_delta_editor_t **editor,
                               clean_checkout,
                               diff3_cmd,
                               preserved_exts,
+                              NULL, NULL, /* hydrate func/baton */
                               fetch_dirents_func, fetch_dirents_baton,
                               conflict_func, conflict_baton,
                               external_func, external_baton,

--- a/subversion/libsvn_wc/wc_db.h
+++ b/subversion/libsvn_wc/wc_db.h
@@ -3181,6 +3181,21 @@ typedef svn_error_t * (*svn_wc__db_textbase_hydrate_cb_t)(
   void *cancel_baton,
   apr_pool_t *scratch_pool);
 
+/* Hydrate the pristine for one file.
+ */
+svn_error_t *
+svn_wc__db_textbase_hydrate(svn_wc__db_t *db,
+                            const char *wri_abspath,
+                            svn_wc__db_textbase_hydrate_cb_t hydrate_callback,
+                            void *hydrate_baton,
+                            svn_cancel_func_t cancel_func,
+                            void *cancel_baton,
+                            const svn_checksum_t *checksum,
+                            const char *repos_root_url,
+                            const char *repos_relpath,
+                            svn_revnum_t revision,
+                            apr_pool_t *scratch_pool);
+
 /* Synchronize the state of the text-bases in DB.
 
    If ALLOW_HYDRATE is true, fetch the referenced but missing text-base

--- a/subversion/libsvn_wc/wc_db_textbase.c
+++ b/subversion/libsvn_wc/wc_db_textbase.c
@@ -168,18 +168,18 @@ svn_wc__db_textbase_walk(svn_wc__db_t *db,
   return SVN_NO_ERROR;
 }
 
-static svn_error_t *
-textbase_hydrate(svn_wc__db_t *db,
-                 const char *wri_abspath,
-                 svn_wc__db_textbase_hydrate_cb_t hydrate_callback,
-                 void *hydrate_baton,
-                 svn_cancel_func_t cancel_func,
-                 void *cancel_baton,
-                 const svn_checksum_t *checksum,
-                 const char *repos_root_url,
-                 const char *repos_relpath,
-                 svn_revnum_t revision,
-                 apr_pool_t *scratch_pool)
+svn_error_t *
+svn_wc__db_textbase_hydrate(svn_wc__db_t *db,
+                            const char *wri_abspath,
+                            svn_wc__db_textbase_hydrate_cb_t hydrate_callback,
+                            void *hydrate_baton,
+                            svn_cancel_func_t cancel_func,
+                            void *cancel_baton,
+                            const svn_checksum_t *checksum,
+                            const char *repos_root_url,
+                            const char *repos_relpath,
+                            svn_revnum_t revision,
+                            apr_pool_t *scratch_pool)
 {
   svn_stream_t *install_stream;
   svn_wc__db_install_data_t *install_data;
@@ -326,10 +326,12 @@ svn_wc__db_textbase_sync(svn_wc__db_t *db,
                            svn_checksum_to_cstring_display(checksum, iterpool));
                 }
 
-              err = textbase_hydrate(db, local_abspath, hydrate_callback,
-                                     hydrate_baton, cancel_func, cancel_baton,
-                                     checksum, repos_root_url, repos_relpath,
-                                     revision, iterpool);
+              err = svn_wc__db_textbase_hydrate(db, local_abspath,
+                                                hydrate_callback, hydrate_baton,
+                                                cancel_func, cancel_baton,
+                                                checksum, repos_root_url,
+                                                repos_relpath, revision,
+                                                iterpool);
               /* If read access is unauthorized, for some operations we need
                * to continue even though we failed to fetch the textbase. */
               if (err && err->apr_err == SVN_ERR_RA_NOT_AUTHORIZED)


### PR DESCRIPTION
… pristines.

Branched from 'pristines-on-demand-on-mwf'. This commit, as well as
branching, applies the proof-of-concept patch sent to dev@ thread "Issue
#525/#4892: on only fetching the pristines we really need".

This is a proof-of-concept patch, enabling "update" to fetch minimal
pristines, using a deeper callback to fetch them at the point of use.

Currently, "restore" functionality of the update is disabled. A similar
approach could enable it to fetch at point of use as well. Currently it
being disabled leads to the following test suite failures:

  FAIL:  basic_tests.py 1: basic checkout of a wc
  FAIL:  copy_tests.py 20: copy over a missing file
  FAIL:  relocate_tests.py 1: relocate with deleted, missing and copied entries
  FAIL:  stat_tests.py 13: timestamp behaviour
  FAIL:  update_tests.py 6: delete files and update to resolve text conflicts
  FAIL:  update_tests.py 9: update missing items (by name) in working copy
  FAIL:  update_tests.py 14: update missing dir to rev in which it is absent
  FAIL:  update_tests.py 15: another "hudson" problem: updates that delete
  FAIL:  upgrade_tests.py 24: test upgrading a working copy with missing subdir
  FAIL:  upgrade_tests.py 27: upgrade with missing replaced dir

This patch leads to one additional test failure:

  FAIL:  externals_tests.py 68: check file external recorded info

* subversion/include/private/svn_wc_private.h
  (svn_wc__textbase_hydrate_cb_t): Moved to earlier.
  (svn_wc__get_update_editor): Add a hydrate callback.
  (svn_wc__crawl_revisions6): New, bumped... ### see below.

* subversion/libsvn_client/client.h,
  subversion/libsvn_client/textbase.c
  (svn_client__textbase_get_hydrator): New.

* subversion/libsvn_client/switch.c
  (svn_client__switch_internal): ### hydrate before conflicts resolver

* subversion/libsvn_client/update.c
  (update_internal): 
  (svn_client__update_internal): Don't hydrate everything at the start.
    Pass a hydrate callback down to the WC update operation. 
    ### TODO/TO-CHECK: Also hydrate before conflicts resolver.

* subversion/libsvn_wc/adm_crawler.c
  (maybe_restore_node): ### TEMPORARY: don't restore.
  (svn_wc_crawl_revisions5): Bump to ...6(), adding a hydrate callback.
    ### TODO: use the callback for "restore".

* subversion/libsvn_wc/deprecated.c
  (svn_wc_get_update_editor4): Pass null for hydrate callback.

* subversion/libsvn_wc/update_editor.c
  (lazy_open_source): Use a hydrate callback to hydrate if pristine is
    missing.
  (edit_baton,
   make_editor,
   svn_wc__get_update_editor,
   svn_wc__get_switch_editor): Pass a hydrate callback through.

* subversion/libsvn_wc/wc_db.h,
  subversion/libsvn_wc/wc_db_textbase.c
  (svn_wc__db_textbase_hydrate): Newly public; renamed ...
  (textbase_hydrate): ... from this.
  (svn_wc__db_textbase_sync): Track the rename.


git-svn-id: https://svn.apache.org/repos/asf/subversion/branches/pristines-on-demand-issue4892@1898948 13f79535-47bb-0310-9956-ffa450edef68